### PR TITLE
removed unnecessary re-configuration of processor every time it is executed

### DIFF
--- a/engine/handler.go
+++ b/engine/handler.go
@@ -24,12 +24,6 @@ func (e *Engine) executeProcessor(flow *definitions.EngineFlowObject, fileHandle
 		return fmt.Errorf("processor %s not found in enabled processors cache", currentNode.ID)
 	}
 
-	err := processor.SetConfig(currentNode.Config)
-	if err != nil {
-		e.log.WithError(err).Error("failed to set processor configuration")
-		return fmt.Errorf("%w: %v", ErrFailedToSetProcessorConfig, err)
-	}
-
 	logEntry := definitions.LogEntry{
 		SessionID:             sessionID,
 		ProcessorName:         currentNode.Name,


### PR DESCRIPTION
The processor's configuration is already set when activating the flow, doing it again is redundant 